### PR TITLE
updated NRC calls and added a lot of useful print statements

### DIFF
--- a/quick_grism_sim.py
+++ b/quick_grism_sim.py
@@ -1,19 +1,70 @@
+from sys import argv
 import pynrc
 pynrc.setup_logging('WARN', verbose=False)
 from pynrc.nrc_utils import S
 
+# # Initialize a NIRCam Grism observation in Stripe mode
+# for oneFilt,nGROUP in zip(['F444W','F322W2'],[12,6]):
+#     print('Starting Loop Iteration with filter {} & ngroups {}'.format(oneFilt,nGROUP))
+#
+#     nrcWL = pynrc.NIRCam('F210M', pupil='Weak Lens +8', module='A', nint=2,ngroup=nGROUP,
+#                          wind_mode='STRIPE', xpix=2048, ypix=256)
+#
+#     print('Allocated SW NRC instance for {} & {}'.format(oneFilt,nGROUP))
+#
+#     nrc = pynrc.NIRCam(oneFilt, pupil='GRISM0', module='A', nint=2,ngroup=nGROUP,
+#                        wind_mode='STRIPE', xpix=2048, ypix=256,read_mode='BRIGHT1')
+#
+#     print('Allocated LW NRC instance for {} & {}'.format(oneFilt,nGROUP))
+#
+#     # Specify name of output file.
+#     # Time stamps will be automatically inserted for unique file names.
+#     bpJ = S.ObsBandpass('johnson,j')
+#     sp = pynrc.stellar_spectrum('K7V', 9.2, 'vegamag', bpJ)
+#     file_out = 'sim_img/grism/NRCALONG_'+oneFilt+'_'
+#     file_outWL = 'sim_img/grism/NRCA1_'+oneFilt+'_'
+#     res_sp = nrc.gen_exposures(  sp, file_out)
+#     res_wl = nrcWL.gen_exposures(sp, file_outWL)
+
 # Initialize a NIRCam Grism observation in Stripe mode 
 for oneFilt,nGROUP in zip(['F444W','F322W2'],[12,6]):
-    nrc = pynrc.NIRCam(oneFilt, pupil='GRISM0', module='A', nint=2,ngroup=nGROUP,
-                       wind_mode='STRIPE', xpix=2048, ypix=256,read_mode='BRIGHT1')
-
+    print()
+    # oneFilt,nGROUP = list(zip(['F444W','F322W2'],[12,6]))[0]
+    
+    print('Starting Loop Iteration with filter {} & ngroups {}'.format(oneFilt,nGROUP))
+    
     nrcWL = pynrc.NIRCam('F210M', pupil='Weak Lens +8', module='A', nint=2,ngroup=nGROUP,
                          wind_mode='STRIPE', xpix=2048, ypix=256)
+    
+    print('Allocated SW NRC instance for {} & {}'.format(oneFilt,nGROUP))
+    
+    nrcGrism = pynrc.NIRCam(oneFilt, pupil='GRISM0', module='A', nint=2,ngroup=nGROUP,
+                       wind_mode='STRIPE', xpix=2048, ypix=256,read_mode='BRIGHT1')
+    
+    print('Allocated LW NRC instance for {} & {}'.format(oneFilt,nGROUP))
+    
     # Specify name of output file.
     # Time stamps will be automatically inserted for unique file names.
     bpJ = S.ObsBandpass('johnson,j')
-    sp = pynrc.stellar_spectrum('K7V', 9.2, 'vegamag', bpJ)
+    
+    print('Allocated Normalization Bandwidth: J-band')
+    
+    stellarType = 'K7V'
+    Jmag        = 9.2
+    sp = pynrc.stellar_spectrum(stellarType, Jmag, 'vegamag', bpJ)
+    
+    print('Allocated Stellar spectrum with SType: {} and Jmag: {}'.format(stellarType, Jmag))
+    
     file_out = 'sim_img/grism/NRCALONG_'+oneFilt+'_'
     file_outWL = 'sim_img/grism/NRCA1_'+oneFilt+'_'
-    res_sp = nrc.gen_exposures(sp, file_out,targ_name='WASP-80')
-    res_wl = nrcWL.gen_exposures(sp, file_outWL,targ_name='WASP-80')
+    
+    print('Assigned SW file out as {}'.format(file_outWL))
+    print('Assigned LW file out as {}'.format(file_out))
+    
+    print('Generating SW Exposure')
+    res_wl = nrcWL.gen_exposures(sp, file_outWL)
+    
+    print('Generating LW Exposure')
+    res_sp = nrcGrism.gen_exposures(  sp, file_out)
+    
+    print('Completed iteration {} & {}'.format(oneFilt, nGROUP))

--- a/quick_grism_sim.py
+++ b/quick_grism_sim.py
@@ -3,29 +3,6 @@ import pynrc
 pynrc.setup_logging('WARN', verbose=False)
 from pynrc.nrc_utils import S
 
-# # Initialize a NIRCam Grism observation in Stripe mode
-# for oneFilt,nGROUP in zip(['F444W','F322W2'],[12,6]):
-#     print('Starting Loop Iteration with filter {} & ngroups {}'.format(oneFilt,nGROUP))
-#
-#     nrcWL = pynrc.NIRCam('F210M', pupil='Weak Lens +8', module='A', nint=2,ngroup=nGROUP,
-#                          wind_mode='STRIPE', xpix=2048, ypix=256)
-#
-#     print('Allocated SW NRC instance for {} & {}'.format(oneFilt,nGROUP))
-#
-#     nrc = pynrc.NIRCam(oneFilt, pupil='GRISM0', module='A', nint=2,ngroup=nGROUP,
-#                        wind_mode='STRIPE', xpix=2048, ypix=256,read_mode='BRIGHT1')
-#
-#     print('Allocated LW NRC instance for {} & {}'.format(oneFilt,nGROUP))
-#
-#     # Specify name of output file.
-#     # Time stamps will be automatically inserted for unique file names.
-#     bpJ = S.ObsBandpass('johnson,j')
-#     sp = pynrc.stellar_spectrum('K7V', 9.2, 'vegamag', bpJ)
-#     file_out = 'sim_img/grism/NRCALONG_'+oneFilt+'_'
-#     file_outWL = 'sim_img/grism/NRCA1_'+oneFilt+'_'
-#     res_sp = nrc.gen_exposures(  sp, file_out)
-#     res_wl = nrcWL.gen_exposures(sp, file_outWL)
-
 # Initialize a NIRCam Grism observation in Stripe mode 
 for oneFilt,nGROUP in zip(['F444W','F322W2'],[12,6]):
     print()


### PR DESCRIPTION
I had a lot of trouble getting this to run successfully.  It turned out the problems were all inside PYRNC (github.com/jarronl/pynrc) and POPPY (github.com/mperrin/poppy).  

But going through the exercise of 'fixing' tso_sims, I made a lot of useful print statements that I think you would like to keep.

ALSO: the `nrc.gen_exposures` command no longer accepts the keyword `targ_name`; so removed that too.  

This call runs through to success easily.